### PR TITLE
Fix UI initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## v2.0.1
+
+- Fix UI initial state to fields not results
+
+## v2.0.0
+
+- Enhanced UI
+
+## v1.0.0
+
+- Initial version

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Altis Experiments
  * Description: A companion plugin to Altis Analytics that provides a web experimentation framework.
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: Human Made Limited
  * Author URL: https://humanmade.com/
  */

--- a/src/features/titles/plugin.js
+++ b/src/features/titles/plugin.js
@@ -24,7 +24,7 @@ const Plugin = props => {
 		results,
 		end_time: endTime,
 	} = test;
-	const { winner } = results;
+	const { winner = false } = results;
 
 	const classNames = [
 		started && 'is-started',


### PR DESCRIPTION
The results object only had the timestamp to fetch results after - this is fine but meant we needed the default value for the `winner` property still.