### PR TITLE
Remove need for shadow dom, use attributes for variants

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -634,6 +634,10 @@ function output_ab_test_html_for_post( string $test_id, int $post_id, string $de
 		return $default_output;
 	}
 
+	$variant_output = array_map( function ( $variant ) use ( $test, $post_id, $args ) {
+		return call_user_func_array( $test['variant_callback'], [ $variant, $post_id, $args ] );
+	}, $variants );
+
 	// Generate AB Test markup.
 	ob_start();
 	?>
@@ -642,14 +646,10 @@ function output_ab_test_html_for_post( string $test_id, int $post_id, string $de
 		post-id="<?php echo esc_attr( $post_id ); ?>"
 		traffic-percentage="<?php echo get_ab_test_traffic_percentage_for_post( $test_id, $post_id ); ?>"
 		goal="<?php echo esc_attr( $test['goal'] ); ?>"
-		variant-count="<?php echo intval( count( $variants ) ); ?>"
+		fallback="<?php echo esc_attr( $default_output ); ?>"
+		variants="<?php echo esc_attr( wp_json_encode( $variant_output, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) ); ?>"
 	>
-		<test-fallback><?php echo $default_output; ?></test-fallback>
-		<?php foreach ( $variants as $variant ) : ?>
-		<test-variant>
-			<?php echo call_user_func_array( $test['variant_callback'], [ $variant, $post_id, $args ] ); ?>
-		</test-variant>
-		<?php endforeach; ?>
+		<?php echo $default_output; ?>
 	</ab-test>
 	<?php
 	return ob_get_clean();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "altis-experiments",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1016,11 +1016,6 @@
         "@webassemblyjs/wast-parser": "1.8.5",
         "@xtuc/long": "4.2.2"
       }
-    },
-    "@webcomponents/shadydom": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadydom/-/shadydom-1.6.0.tgz",
-      "integrity": "sha512-2r9SGHv13MS488ZwYXd2W123bXn/ZjWo5/pO4s9FOZmpEYv8ALWRc4VazmiFNl+3n4Cdu0uvCwju4V6ivgZKXA=="
     },
     "@wordpress/babel-plugin-import-jsx-pragma": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.4.5",
-    "@webcomponents/shadydom": "^1.6.0",
     "@wordpress/babel-preset-default": "^4.3.0",
     "babel-loader": "^8.0.6",
     "deepmerge": "^4.0.0",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Altis Experiments
  * Description: A companion plugin to Altis Analytics that provides a web experimentation framework.
- * Version: 2.0.1
+ * Version: 2.0.2
  * Author: Human Made Limited
  * Author URL: https://humanmade.com/
  */

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -1,300 +1,235 @@
-( async () => {
-	// Set public path for dynamic chunks.
-	// eslint-disable-next-line
-	__webpack_public_path__ = window.Altis.Analytics.Experiments.BuildURL;
+/**
+ * Test element base class.
+ */
+class Test extends HTMLElement {
 
-	const supportsShadowDOMV1 = ! ! HTMLElement.prototype.attachShadow;
+	storageKey = '_altis_tests';
 
-	// Load polyfill async if needed.
-	if ( ! supportsShadowDOMV1 ) {
-		await import( '@webcomponents/shadydom' );
+	get testId() {
+		return this.getAttribute( 'test-id' );
 	}
 
-	/**
-	 * Custom test fallback element.
-	 */
-	class TestFallback extends HTMLElement {
-		constructor() {
-			super();
-			const root = this.attachShadow( { mode: 'open' } );
-			root.innerHTML = '<slot></slot>';
-		}
+	get postId() {
+		return this.getAttribute( 'post-id' );
 	}
 
-	/**
-	 * Custom variant element.
-	 */
-	class TestVariant extends HTMLElement {
-		constructor() {
-			super();
-			const root = this.attachShadow( { mode: 'open' } );
-			root.innerHTML = '<slot></slot>';
-		}
+	get testIdWithPost() {
+		return `${ this.testId }_${ this.postId }`;
 	}
 
-	/**
-	 * Test element base class.
-	 */
-	class Test extends HTMLElement {
+	get trafficPercentage() {
+		return this.getAttribute( 'traffic-percentage' );
+	}
 
-		storageKey = '_altis_tests';
+	get variants() {
+		return JSON.parse( this.getAttribute( 'variants' ) ) || [];
+	}
 
-		get testId() {
-			return this.getAttribute( 'test-id' );
+	get fallback() {
+		return this.getAttribute( 'fallback' );
+	}
+
+	get goal() {
+		return this.getAttribute( 'goal' );
+	}
+
+	constructor() {
+		super();
+	}
+
+	connectedCallback() {
+		// Extract test set by URL parameters.
+		const regex = new RegExp( `(utm_campaign|set_test)=test_${ this.testIdWithPost }:(\\d+)`, 'i' );
+		const url_test = unescape( window.location.search ).match( regex );
+		if ( url_test ) {
+			this.addTestForUser( { [ this.testIdWithPost ]: parseInt( url_test[ 2 ], 10 ) } );
 		}
 
-		get postId() {
-			return this.getAttribute( 'post-id' );
+		// Initialise component.
+		this.init();
+	}
+
+	init() {
+		window.console && window.console.error( 'Children of Class Test must implement an init() method.' );
+	}
+
+	getTestsForUser() {
+		return JSON.parse( window.localStorage.getItem( this.storageKey ) ) || {};
+	}
+
+	addTestForUser( test ) {
+		window.localStorage.setItem( this.storageKey, JSON.stringify( {
+			...this.getTestsForUser(),
+			...test,
+		} ) );
+	}
+
+}
+
+/**
+ * Custom AB Test element.
+ */
+class ABTest extends Test {
+
+	storageKey = '_altis_ab_tests';
+
+	init() {
+		// Assign variant ID.
+		const variantId = this.getVariantId();
+
+		// Don't process if not part of the test.
+		if ( variantId === false ) {
+			this.outerHTML = this.fallback;
+			return;
 		}
 
-		get testIdWithPost() {
-			return `${ this.testId }_${ this.postId }`;
+		// Get data for event listener.
+		const testId = this.testId;
+		const postId = this.postId;
+		const parent = this.parentNode;
+		const goal = this.goal.split( ':' );
+		const [ eventType, selector ] = goal;
+
+		// Get the variant content.
+		const variant = this.variants[ variantId || 0 ];
+
+		// Replace the contents of our <ab-test> element.
+		this.outerHTML = variant;
+
+		// Call goal handler on parent.
+		const goalHandler = Test.goalHandlers[ eventType ] || false;
+		if ( ! eventType || ! goalHandler ) {
+			return;
 		}
 
-		get trafficPercentage() {
-			return this.getAttribute( 'traffic-percentage' );
-		}
-
-		get variantCount() {
-			return parseInt( this.getAttribute( 'variant-count' ), 10 );
-		}
-
-		get goal() {
-			return this.getAttribute( 'goal' );
-		}
-
-		constructor() {
-			super();
-			const root = this.attachShadow( { mode: 'open' } );
-			root.innerHTML = '<slot></slot>';
-		}
-
-		connectedCallback() {
-			// Extract test set by URL parameters.
-			const regex = new RegExp( `(utm_campaign|set_test)=test_${ this.testIdWithPost }:(\\d+)`, 'i' );
-			const url_test = unescape( window.location.search ).match( regex );
-			if ( url_test ) {
-				this.addTestForUser( { [ this.testIdWithPost ]: parseInt( url_test[ 2 ], 10 ) } );
+		// Get nodes to bind click handler for.
+		let nodes = [ parent ];
+		if ( selector ) {
+			nodes = parent.querySelectorAll( selector );
+		} else if ( goalHandler.closest.length ) {
+			// Find closest allowed element.
+			const allowedNodes = goalHandler.closest.map( tag => tag.toUpperCase() );
+			let el = parent;
+			while ( el.parentNode && allowedNodes.indexOf( el.nodeName ) < 0 ) {
+				el = el.parentNode;
 			}
-
-			// Initialise component.
-			this.init();
+			if ( allowedNodes.indexOf( el.nodeName ) >= 0 ) {
+				nodes = [ el ];
+			}
 		}
 
-		init() {
-			window.console && window.console.error( 'Children of Class Test must implement an init() method.' );
-		}
-
-		getTestsForUser() {
-			return JSON.parse( window.localStorage.getItem( this.storageKey ) ) || {};
-		}
-
-		addTestForUser( test ) {
-			window.localStorage.setItem( this.storageKey, JSON.stringify( {
-				...this.getTestsForUser(),
-				...test,
-			} ) );
-		}
-
+		// Apply goal callback for each found node.
+		nodes.forEach( node => {
+			goalHandler.callback( node, ( attributes = {}, metrics = {} ) => {
+				window.Altis.Analytics.record( eventType, {
+					attributes: {
+						...attributes,
+						eventTestId: testId,
+						eventPostId: postId,
+						eventVariantId: variantId,
+					},
+					metrics: {
+						...metrics,
+					},
+				} );
+			} );
+		} );
 	}
 
-	/**
-	 * Custom AB Test element.
-	 */
-	class ABTest extends Test {
+	getVariantId() {
+		const testId = this.testIdWithPost;
+		const trafficPercentage = this.trafficPercentage;
 
-		storageKey = '_altis_ab_tests';
-
-		init() {
-			// Assign variant ID.
-			const variantId = this.getVariantId();
-
-			// Get data for event listener.
-			const variantCount = this.variantCount;
-			const goal = this.goal.split( ':' );
-			const testId = this.testId;
-			const postId = this.postId;
-			const element = this;
-			const data = {
-				testId,
-				postId,
-				variantId,
-				eventType: goal[ 0 ],
-				selector: goal[ 1 ] || false,
-			};
-
-			// Track if we've initialised yet as slotchange can fire multiple times.
-			let initialised = false;
-
-			// Get the slot element.
-			const slot = this.shadowRoot.querySelector( 'slot' );
-			slot.addEventListener( 'slotchange', () => {
-				if ( initialised ) {
-					return;
-				}
-
-				let fallback = Array.from( slot.assignedElements() )
-					.filter( node => node.nodeName === 'TEST-FALLBACK' );
-
-				// Use fallback if we're not in the test.
-				if ( fallback.length > 0 && variantId === false ) {
-					element.outerHTML = fallback[0].innerHTML;
-					initialised = true;
-					return;
-				}
-
-				let variants = Array.from( slot.assignedElements() )
-					.filter( node => node.nodeName === 'TEST-VARIANT' );
-
-				// Wait for all our variants to be available.
-				if ( variants.length !== variantCount ) {
-					return;
-				}
-
-				initialised = true;
-
-				const variant = variants[ variantId || 0 ]; // Default to control.
-				const parent = element.parentNode;
-
-				// Replace this entire <ab-test> element.
-				element.outerHTML = variant.innerHTML;
-
-				// Call goal handler on parent.
-				const goalHandler = Test.goalHandlers[ goal[ 0 ] ] || false;
-				if ( variantId === false || ! goal[ 0 ] || ! goalHandler ) {
-					return;
-				}
-
-				// Get nodes to bind click handler for.
-				let nodes = [ parent ];
-				if ( data.selector ) {
-					nodes = parent.querySelectorAll( data.selector );
-				} else if ( goalHandler.closest.length ) {
-					// Find closest allowed element.
-					const allowedNodes = goalHandler.closest.map( tag => tag.toUpperCase() );
-					let el = parent;
-					while ( el.parentNode && allowedNodes.indexOf( el.nodeName ) < 0 ) {
-						el = el.parentNode;
-					}
-					if ( allowedNodes.indexOf( el.nodeName ) >= 0 ) {
-						nodes = [ el ];
-					}
-				}
-
-				// Apply goal callback for each found node.
-				nodes.forEach( node => {
-					goalHandler.callback( node, ( attributes = {}, metrics = {} ) => {
-						window.Altis.Analytics.record( data.eventType, {
-							attributes: {
-								...attributes,
-								eventTestId: data.testId,
-								eventPostId: data.postId,
-								eventVariantId: data.variantId,
-							},
-							metrics: {
-								...metrics,
-							},
-						} );
-					} );
+		// Check if this user already have a variant for this test.
+		const currentTests = this.getTestsForUser();
+		let variantId = false;
+		// Test variant can be 0 so check for not undefined and not strictly false and
+		// that it's a valid index.
+		if (
+			typeof currentTests[ testId ] !== 'undefined' &&
+			currentTests[ testId ] !== false &&
+			currentTests[ testId ] < this.variants.length
+		) {
+			variantId = currentTests[ testId ];
+		} else if ( currentTests[ testId ] === false ) {
+			return variantId;
+		} else {
+			// Otherwise lets check the probability we should experiment on this individual.
+			// That sounded weird.
+			if ( Math.random() * 100 > trafficPercentage ) {
+				// Exclude from this test.
+				this.addTestForUser( {
+					[ testId ]: false,
 				} );
+				return variantId;
+			}
+			// Add one of the variants to the cookie.
+			variantId = Math.floor( Math.random() * this.variants.length );
+			this.addTestForUser( {
+				[ testId ]: variantId,
 			} );
 		}
 
-		getVariantId() {
-			const testId = this.testIdWithPost;
-			const trafficPercentage = this.trafficPercentage;
-
-			// Check if this user already have a variant for this test.
-			const currentTests = this.getTestsForUser();
-			let variantId = false;
-			// Test variant can be 0 so check for not undefined and not strictly false and
-			// that it's a valid index.
-			if (
-				typeof currentTests[ testId ] !== 'undefined' &&
-				currentTests[ testId ] !== false &&
-				currentTests[ testId ] < this.variantCount
-			) {
-				variantId = currentTests[ testId ];
-			} else if ( currentTests[ testId ] === false ) {
-				return variantId;
-			} else {
-				// Otherwise lets check the probability we should experiment on this individual.
-				// That sounded weird.
-				if ( Math.random() * 100 > trafficPercentage ) {
-					// Exclude from this test.
-					this.addTestForUser( {
-						[ testId ]: false,
-					} );
-					return variantId;
-				}
-				// Add one of the variants to the cookie.
-				variantId = Math.floor( Math.random() * this.variantCount );
-				this.addTestForUser( {
-					[ testId ]: variantId,
-				} );
-			}
-
-			// Log active test variant for all events.
-			if ( window.Altis && window.Altis.Analytics ) {
-				window.Altis.Analytics.registerAttribute( `test_${ testId }`, variantId );
-			}
-
-			return variantId;
+		// Log active test variant for all events.
+		if ( window.Altis && window.Altis.Analytics ) {
+			window.Altis.Analytics.registerAttribute( `test_${ testId }`, variantId );
 		}
 
+		return variantId;
 	}
 
-	/**
-	 * Static list of goal handlers.
-	 */
-	Test.goalHandlers = {};
+}
 
-	/**
-	 * Add an event handler for recording an analytics event.
-	 * The event is then used to determine the goal success.
-	 *
-	 * Callback receives the target node and a function to record
-	 * to record the event.
-	 *
-	 * @param
-	 */
-	Test.registerGoal = ( name, callback, closest = [] ) => {
-		Test.goalHandlers[ name ] = {
-			callback,
-			closest: Array.isArray( closest ) ? closest : [ closest ],
-		};
+/**
+ * Static list of goal handlers.
+ */
+Test.goalHandlers = {};
+
+/**
+ * Add an event handler for recording an analytics event.
+ * The event is then used to determine the goal success.
+ *
+ * Callback receives the target node and a function to record
+ * to record the event.
+ *
+ * @param <String> name of the goal.
+ * @param <Function> callback to bind an event listener.
+ * @param <String[]> array of allowed node types to bind listener to.
+ */
+Test.registerGoal = ( name, callback, closest = [] ) => {
+	Test.goalHandlers[ name ] = {
+		callback,
+		closest: Array.isArray( closest ) ? closest : [ closest ],
+	};
+};
+
+// Register built in click goal handler.
+Test.registerGoal( 'click', ( element, record ) => {
+	// Collect attributes.
+	const attributes = {
+		elementNode: element.nodeName || '',
+		elementText: element.innerText || '',
+		elementClassName: element.className || '',
+		elementId: element.id || '',
+		elementHref: element.href || '',
 	};
 
-	// Register built in click goal handler.
-	Test.registerGoal( 'click', ( element, record ) => {
-		// Collect attributes.
-		const attributes = {
-			elementNode: element.nodeName || '',
-			elementText: element.innerText || '',
-			elementClassName: element.className || '',
-			elementId: element.id || '',
-			elementHref: element.href || '',
-		};
-
-		// Bind handler.
-		element.addEventListener( 'click', event => {
-			record( Object.assign( {}, attributes, {
-				targetNode: event.target.nodeName || '',
-				targetText: event.target.innerText || '',
-				targetClassName: event.target.className || '',
-				targetId: event.target.id || '',
-				targetSrc: event.target.nodeName === 'IMG' ? event.target.src : '',
-			} ) );
-		} );
-	}, [ 'a' ] );
-
-	// Define custom elements.
-	window.customElements.define( 'test-fallback', TestFallback );
-	window.customElements.define( 'test-variant', TestVariant );
-	window.customElements.define( 'ab-test', ABTest );
-
-	// Expose ABTest methods.
-	window.Altis.Analytics.Experiments = Object.assign( {}, window.Altis.Analytics.Experiments || {}, {
-		registerGoal: Test.registerGoal,
+	// Bind handler.
+	element.addEventListener( 'click', event => {
+		record( Object.assign( {}, attributes, {
+			targetNode: event.target.nodeName || '',
+			targetText: event.target.innerText || '',
+			targetClassName: event.target.className || '',
+			targetId: event.target.id || '',
+			targetSrc: event.target.nodeName === 'IMG' ? event.target.src : '',
+		} ) );
 	} );
-} )();
+}, [ 'a' ] );
+
+// Define custom elements.
+window.customElements.define( 'ab-test', ABTest );
+
+// Expose ABTest methods.
+window.Altis.Analytics.Experiments = Object.assign( {}, window.Altis.Analytics.Experiments || {}, {
+	registerGoal: Test.registerGoal,
+} );


### PR DESCRIPTION
This reduces the `<ab-test>` markup back to a single wrapper element so that `strip_tags()` will produce the desired result if its used somewhere like an attribute.