### PR TITLE
Bind setContent to EB instance

### DIFF
--- a/src/experiments.js
+++ b/src/experiments.js
@@ -247,7 +247,7 @@ class PersonalizationBlock extends HTMLElement {
 		window.Altis.Analytics.on( 'updateAudiences', this.setContent );
 	}
 
-	setContent() {
+	setContent = () => {
 		const audiences = window.Altis.Analytics.getAudiences();
 
 		// Get associated templates.


### PR DESCRIPTION
The handler hooked to the `updateAudiences` event needs to be bound to the EB instance, otherwise you'll get an error about `this` being undefined.