### PR TITLE
Fix for client IDs not being set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.1
+
+- Bug: move client ID assignment to server side rendering
+
 ## v2.2.0
 
 - Update AWS analytics requirement and `AudiencePicker` `onSelect` prop usage

--- a/inc/features/blocks/personalization-variant/block.json
+++ b/inc/features/blocks/personalization-variant/block.json
@@ -11,9 +11,6 @@
             "inserter": false
         },
         "attributes": {
-            "parentId": {
-                "type": "string"
-            },
             "audience": {
                 "type": "number"
             },

--- a/inc/features/blocks/personalization-variant/edit.js
+++ b/inc/features/blocks/personalization-variant/edit.js
@@ -19,7 +19,7 @@ const Edit = ( {
 	const props = {};
 	if ( ! hasChildBlocks ) {
 		// If we don't have any child blocks, show large block appender button.
-		props.renderAppender = () => <InnerBlocks.ButtonBlockAppender />;
+		props.renderAppender = () => <InnerBlocks.DefaultBlockAppender />;
 	}
 
 	return (
@@ -35,7 +35,7 @@ export default compose(
 		const { getBlockOrder } = select( 'core/block-editor' );
 
 		return {
-			hasChildBlocks: () => getBlockOrder( clientId ).length > 0,
+			hasChildBlocks: getBlockOrder( clientId ).length > 0,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/inc/features/blocks/personalization-variant/register.php
+++ b/inc/features/blocks/personalization-variant/register.php
@@ -63,33 +63,25 @@ function enqueue_assets() {
  * the content string represents only the wrapped inner block markup.
  *
  * @param array $attributes The block's attributes object.
- * @param string $innerContent The block's saved content.
+ * @param string $inner_content The block's saved content.
  * @return string The final rendered block markup, as an HTML string.
  */
 function render_block( array $attributes, ?string $inner_content = '' ) : string {
-	$parent_id = $attributes['parentId'] ?? false;
 	$audience = $attributes['audience'] ?? 0;
 	$fallback = $attributes['fallback'] ?? false;
-
-	if ( ! $parent_id ) {
-		trigger_error( 'Personalization block variant has no parent ID set.', E_USER_WARNING );
-		return '';
-	}
 
 	// If this is the fallback variant output the template with different attributes
 	// for easier and more specific targeting by document.querySelector().
 	if ( $fallback ) {
 		return sprintf(
-			'<template data-fallback data-parent-id="%s">%s</template>',
-			esc_attr( $parent_id ),
+			'<template data-fallback data-parent-id="__PARENT_CLIENT_ID__">%s</template>',
 			$inner_content
 		);
 	}
 
 	return sprintf(
-		'<template data-audience="%d" data-parent-id="%s">%s</template>',
+		'<template data-audience="%d" data-parent-id="__PARENT_CLIENT_ID__">%s</template>',
 		esc_attr( $audience ),
-		esc_attr( $parent_id ),
 		$inner_content
 	);
 }

--- a/inc/features/blocks/personalization/block.json
+++ b/inc/features/blocks/personalization/block.json
@@ -8,10 +8,6 @@
             "html": false,
             "align": true
         },
-        "attributes": {
-            "clientId": {
-                "type": "string"
-            }
-        }
+        "attributes": {}
     }
 }

--- a/inc/features/blocks/personalization/components/variant-title.js
+++ b/inc/features/blocks/personalization/components/variant-title.js
@@ -3,6 +3,10 @@ const { __ } = wp.i18n;
 
 // Component for fetching and displaying the variant title string.
 const VariantTitle = ( { variant } ) => {
+	if ( ! variant || typeof variant !== 'object' ) {
+		return '';
+	}
+
 	const audience = useSelect( select => {
 		return select( 'audience' ).getPost( variant.attributes.audience );
 	}, [ variant.attributes.audience ] );

--- a/inc/features/blocks/personalization/edit.js
+++ b/inc/features/blocks/personalization/edit.js
@@ -22,42 +22,31 @@ const { __ } = wp.i18n;
  */
 const ALLOWED_BLOCKS = [ 'altis/personalization-variant' ];
 
-/**
- * Start with a default template of one variant.
- */
-const TEMPLATE = [
-	[ 'altis/personalization-variant' ],
-];
-
 // Audience picker input.
 const Edit = ( {
-	attributes,
 	className,
 	clientId,
 	isSelected,
 	onAddVariant,
 	onCopyVariant,
 	onRemoveVariant,
-	onSetClientId,
-	onSetVariantParents,
 	variants,
 } ) => {
 	// Track currently selected variant.
 	const defaultVariantClientId = ( variants.length > 0 && variants[ 0 ].clientId ) || null;
 	const [ activeVariant, setVariant ] = useState( defaultVariantClientId );
 
-	// Track the active variant index to show in the title.
-	const activeVariantIndex = variants.findIndex( variant => variant.clientId === activeVariant );
-
-	// Set clientId attribute if not set.
+	// Add a default fallback variant if none present.
 	useEffect( () => {
-		onSetClientId();
+		// Ensure at least one variant is present as a fallback.
+		// Note TEMPLATE does not seem to have the desired effect every time.
+		if ( variants.length === 0 ) {
+			setVariant( onAddVariant( { fallback: true } ) );
+		}
 	}, [] );
 
-	// Ensure variant parentId is correct.
-	useEffect( () => {
-		onSetVariantParents();
-	}, [ attributes.clientId ] );
+	// Track the active variant index to show in the title.
+	const activeVariantIndex = variants.findIndex( variant => variant.clientId === activeVariant );
 
 	// Controls that appear before the variant selector buttons.
 	const variantsToolbarControls = [
@@ -123,7 +112,9 @@ const Edit = ( {
 					<span className="altis-experience-block-header__title">
 						{ __( 'Personalized Content', 'altis-experiments' ) }
 						{ ' ・ ' }
-						<VariantTitle variant={ variants[ activeVariantIndex ] } />
+						{ variants.length > 0 && (
+							<VariantTitle variant={ variants[ activeVariantIndex ] } />
+						) }
 					</span>
 					{ isSelected && (
 						<VariantToolbar
@@ -137,7 +128,6 @@ const Edit = ( {
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }
 					renderAppender={ false }
-					template={ TEMPLATE }
 				/>
 			</div>
 		</Fragment>

--- a/inc/features/blocks/personalization/register.php
+++ b/inc/features/blocks/personalization/register.php
@@ -82,11 +82,10 @@ function enqueue_assets() {
  * the content string represents only the wrapped inner block markup.
  *
  * @param array $attributes The block's attributes object.
- * @param string $innerContent The block's saved content.
+ * @param string $inner_content The block's saved content.
  * @return string The final rendered block markup, as an HTML string.
  */
 function render_block( array $attributes, ?string $inner_content = '' ) : string {
-	$client_id = $attributes['clientId'] ?? false;
 	$class_name = $attributes['className'] ?? '';
 	$align = $attributes['align'] ?? 'none';
 
@@ -95,10 +94,9 @@ function render_block( array $attributes, ?string $inner_content = '' ) : string
 		$class_name .= sprintf( 'align%s', $align );
 	}
 
-	if ( ! $client_id ) {
-		trigger_error( 'Personalization block has no client ID set.', E_USER_WARNING );
-		return '';
-	}
+	// Get a unique ID for the block and apply it to the templates in $inner_content.
+	$client_id = wp_generate_uuid4();
+	$inner_content = str_replace( '__PARENT_CLIENT_ID__', $client_id, $inner_content );
 
 	return sprintf(
 		'%s<personalization-block class="%s" client-id="%s"></personalization-block>',

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Altis Experiments
  * Description: A companion plugin to Altis Analytics that provides a web experimentation framework.
- * Version: 2.2.0
+ * Version: 2.2.1
  * Author: Human Made Limited
  * Author URL: https://humanmade.com/
  */


### PR DESCRIPTION
The whole feature was broken, my fault - I think the last test I did after code review was with some existing blocks, only way it could have slipped by.

This update moves the client ID generation and assignment to the server side rendering function to improve robustness, it also fixes the following:

- variant innerblocks appender was never showing due to `hasChildBlocks` being a function not a value
- adding the default fallback variant moved from `withSelect` to a `useEffect` in the edit block to simplify the logic and fix a bug where the updated innerblocks were not actually being added to the parent