### PR TITLE
Style XB header like reusable blocks

### DIFF
--- a/inc/features/blocks/personalization/edit.css
+++ b/inc/features/blocks/personalization/edit.css
@@ -3,32 +3,41 @@
  */
 
 .altis-experience-block-header {
+	align-items: center;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 16px;
-	background: repeating-linear-gradient(
-		315deg,
-		rgba(0, 0, 0, .05),
-		rgba(0, 0, 0, .05) 10px,
-		rgba(255, 255, 255, .05) 10px,
-		rgba(255, 255, 255, .05) 20px
-	);
-	padding: 14px;
-	margin: 0 -14px -28px;
+	font-size: 13px;
+	background: #f8f9f9;
+	color: #555d66;
+	padding: 12px 14px;
+	margin: 0 -14px;
+	display: flex;
 	position: relative;
 	top: -14px;
-	display: flex;
+	border: 1px dashed rgba(145, 151, 162, 0.25);
+}
+
+.wp-block.is-selected .altis-experience-block-header {
+	border-bottom: none;
+	border-color: rgba(66, 88, 99, 0.4);
+	border-left-color: transparent;
+}
+
+.block-editor-block-list__layout .block-editor-block-list__block[data-type="altis/personalization"].is-selected::before {
+	border-left-color: transparent;
+	border-style: dashed;
+	border-width: 1px;
 }
 
 .altis-experience-block-header__title {
 	flex: 1;
-	font-weight: bold;
+	font-weight: 600;
 }
 
 .altis-experience-block-header__toolbar {
 	flex: 0;
 	border: 0;
 	padding: 0;
-	margin: -4px 0;
+	margin: -6px 0;
 	display: flex;
 }
 


### PR DESCRIPTION
This brings the styling inline with the reusable block UI and also removes any assumptions around the margins on blocks within the editor. Things may look a little spaced out but it should play more nicely with different themes that implement their styles in various ways.

Fixes #35
Fixes #33