### PR TITLE
Store XB client ID as attribute

### DIFF
--- a/inc/features/blocks/personalization/block.json
+++ b/inc/features/blocks/personalization/block.json
@@ -8,6 +8,11 @@
             "html": false,
             "align": true
         },
-        "attributes": {}
+        "attributes": {
+            "clientId": {
+                "type": "string",
+                "required": true
+            }
+        }
     }
 }

--- a/inc/features/blocks/personalization/edit.js
+++ b/inc/features/blocks/personalization/edit.js
@@ -1,4 +1,5 @@
 import React, { Fragment, useEffect, useState } from 'react';
+import { v4 as uuid } from 'uuid';
 import VariantTitle from './components/variant-title';
 import VariantPanel from './components/variant-panel';
 import VariantToolbar from './components/variant-toolbar';
@@ -24,14 +25,23 @@ const ALLOWED_BLOCKS = [ 'altis/personalization-variant' ];
 
 // Audience picker input.
 const Edit = ( {
+	attributes,
 	className,
 	clientId,
 	isSelected,
 	onAddVariant,
 	onCopyVariant,
 	onRemoveVariant,
+	setAttributes,
 	variants,
 } ) => {
+	// Set the block clientId if none currently set.
+	useEffect( () => {
+		if ( ! attributes.clientId ) {
+			setAttributes( { clientId: uuid() } );
+		}
+	}, [] );
+
 	// Track currently selected variant.
 	const defaultVariantClientId = ( variants.length > 0 && variants[ 0 ].clientId ) || null;
 	const [ activeVariant, setVariant ] = useState( defaultVariantClientId );
@@ -102,7 +112,7 @@ const Edit = ( {
 					[data-block="${ clientId }"] [data-type="altis/personalization-variant"] {
 						display: none;
 					}
-					[data-block="${ clientId }"] #block-${ activeVariant } {
+					[data-block="${ clientId }"] [data-type="altis/personalization-variant"][data-block="${ activeVariant }"] {
 						display: block;
 					}
 				`,

--- a/inc/features/blocks/personalization/register.php
+++ b/inc/features/blocks/personalization/register.php
@@ -86,8 +86,15 @@ function enqueue_assets() {
  * @return string The final rendered block markup, as an HTML string.
  */
 function render_block( array $attributes, ?string $inner_content = '' ) : string {
+	$client_id = $attributes['clientId'] ?? null;
 	$class_name = $attributes['className'] ?? '';
 	$align = $attributes['align'] ?? 'none';
+
+	// Warn if a client ID is not set.
+	if ( ! $client_id ) {
+		trigger_error( 'Personalized content blocks must have a client ID set to track impressions. Please re-save the post content to generate one.', E_USER_WARNING );
+		$client_id = wp_generate_uuid4();
+	}
 
 	// Add alignment class.
 	if ( ! empty( $align ) ) {
@@ -95,7 +102,6 @@ function render_block( array $attributes, ?string $inner_content = '' ) : string
 	}
 
 	// Get a unique ID for the block and apply it to the templates in $inner_content.
-	$client_id = wp_generate_uuid4();
 	$inner_content = str_replace( '__PARENT_CLIENT_ID__', $client_id, $inner_content );
 
 	return sprintf(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "altis-experiments",
-  "version": "2.0.4",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/cli": {
       "version": "7.8.4",
@@ -6925,6 +6924,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
+      "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,16 +25,17 @@
     "@wordpress/babel-preset-default": "^4.12.1",
     "babel-loader": "^8.1.0",
     "classnames": "^2.2.6",
+    "clean-webpack-plugin": "^3.0.0",
     "deepmerge": "^4.2.2",
     "dom-scroll-into-view": "^2.0.1",
+    "dynamic-public-path-webpack-plugin": "^1.0.4",
     "styled-components": "^4.4.1",
+    "uuid": "^8.1.0",
     "webpack": "^4.43.0",
     "webpack-bundle-analyzer": "^3.7.0",
     "webpack-cli": "^3.3.11",
     "webpack-manifest-plugin": "^2.2.0",
-    "webpack-subresource-integrity": "^1.4.0",
-    "dynamic-public-path-webpack-plugin": "^1.0.4",
-    "clean-webpack-plugin": "^3.0.0"
+    "webpack-subresource-integrity": "^1.4.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
This reinstates the fixed client ID generation that will allow us to track impressions per XB instance. We only need the parent block to have this ID though as the variants can be handled on server side render.

The other key change compared to the previous version is that we still support Xbs without a client ID by generating one if it's missing, so content will continue to function but we can't track it using analytics data easily.