### PR TITLE
Add better palceholder text for variants

### DIFF
--- a/inc/features/blocks/personalization/components/variant-panel.js
+++ b/inc/features/blocks/personalization/components/variant-panel.js
@@ -7,7 +7,7 @@ const { PanelBody } = wp.components;
 const { useDispatch } = wp.data;
 const { __ } = wp.i18n;
 
-const VariantPanel = ( { variant } ) => {
+const VariantPanel = ( { variant, placeholder = null } ) => {
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 
 	if ( variant.attributes.fallback ) {
@@ -21,9 +21,9 @@ const VariantPanel = ( { variant } ) => {
 	}
 
 	return (
-		<PanelBody title={ <VariantTitle variant={ variant } /> }>
+		<PanelBody title={ <VariantTitle variant={ variant } placeholder={ placeholder } /> }>
 			<AudiencePicker
-				label={ __( 'Audience' ) }
+				label={ __( 'Audience', 'altis-experiments' ) }
 				audience={ variant.attributes.audience }
 				onSelect={ audience => updateBlockAttributes( variant.clientId, { audience } ) }
 				onClearSelection={ () => updateBlockAttributes( variant.clientId, { audience: null } ) }

--- a/inc/features/blocks/personalization/components/variant-title.js
+++ b/inc/features/blocks/personalization/components/variant-title.js
@@ -2,7 +2,7 @@ const { useSelect } = wp.data;
 const { __ } = wp.i18n;
 
 // Component for fetching and displaying the variant title string.
-const VariantTitle = ( { variant } ) => {
+const VariantTitle = ( { variant, placeholder = null } ) => {
 	if ( ! variant || typeof variant !== 'object' ) {
 		return '';
 	}
@@ -18,6 +18,9 @@ const VariantTitle = ( { variant } ) => {
 	}
 
 	if ( ! variant.attributes.audience ) {
+		if ( placeholder ) {
+			return placeholder;
+		}
 		return __( 'Select audience', 'altis-experiments' );
 	}
 

--- a/inc/features/blocks/personalization/edit.js
+++ b/inc/features/blocks/personalization/edit.js
@@ -15,7 +15,7 @@ const {
 	Button,
 	Toolbar,
 } = wp.components;
-const { __ } = wp.i18n;
+const { __, sprintf } = wp.i18n;
 
 /**
  * Only variants can be direct descendents so that we can generate
@@ -86,24 +86,35 @@ const Edit = ( {
 					controls={ variantsToolbarControls }
 				>
 					<div className="altis-variants-toolbar__tabs">
-						{ variants.map( variant => (
+						{ variants.map( ( variant, index ) => (
 							<Button
 								key={ `variant-select-${ variant.clientId }` }
 								className={ `altis-variant-button components-icon-button has-text ${ activeVariant === variant.clientId && 'is-active' }` }
 								title={ __( 'Select variant', 'altis-experiments' ) }
 								onClick={ () => setVariant( variant.clientId ) }
 							>
-								<VariantTitle variant={ variant } />
+								<VariantTitle variant={ variant } placeholder={ sprintf( __( 'Variant %d', 'altis-experiments' ), index + 1 ) } />
 							</Button>
 						) ) }
 					</div>
 				</Toolbar>
 			</BlockControls>
 			<InspectorControls>
-				{ variants.map( variant => (
+				<div className="components-panel__body is-opened">
+					<Button
+						onClick={ () => setVariant( onAddVariant() ) }
+						isLarge
+						isSecondary
+					>
+						{ __( 'Add a variant', 'altis-experiments' ) }
+					</Button>
+				</div>
+				{ variants.map( ( variant, index ) => (
 					<VariantPanel
+						className={ `variant-settings-${ variant.clientId }` }
 						key={ `variant-settings-${ variant.clientId }` }
 						variant={ variant }
+						placeholder={ sprintf( __( 'Variant %d', 'altis-experiments' ), index + 1 ) }
 					/>
 				) ) }
 			</InspectorControls>
@@ -123,7 +134,10 @@ const Edit = ( {
 						{ __( 'Personalized Content', 'altis-experiments' ) }
 						{ ' ・ ' }
 						{ variants.length > 0 && (
-							<VariantTitle variant={ variants[ activeVariantIndex ] } />
+							<VariantTitle
+								variant={ variants[ activeVariantIndex ] }
+								placeholder={ sprintf( __( 'Variant %d', 'altis-experiments' ), activeVariantIndex + 1 ) }
+							/>
 						) }
 					</span>
 					{ isSelected && (


### PR DESCRIPTION
Right XB variant titles fall back to saying "Select Audience", this is confusing for the tab buttons that dont select an audience. This changes the output to say "Variant 1" etc...

Fixes #47