### PR TITLE
Add XB metrics display

### DIFF
--- a/inc/features/blocks/namespace.php
+++ b/inc/features/blocks/namespace.php
@@ -319,7 +319,7 @@ function get_views( string $block_id, ?int $post_id = null ) {
 		$views['post_id'] = $post_id;
 	}
 
-	// wp_cache_set( $key, $views, 'altis-xbs', MINUTE_IN_SECONDS );
+	wp_cache_set( $key, $views, 'altis-xbs', MINUTE_IN_SECONDS );
 
 	return $views;
 }

--- a/inc/features/blocks/namespace.php
+++ b/inc/features/blocks/namespace.php
@@ -172,7 +172,6 @@ function sanitize_id( $param ) : string {
  * @return boolean
  */
 function check_views_permission() : bool {
-	return true;
 	$type = get_post_type_object( Audiences\POST_TYPE );
 	return current_user_can( $type->cap->edit_posts );
 }

--- a/inc/features/blocks/namespace.php
+++ b/inc/features/blocks/namespace.php
@@ -7,6 +7,12 @@
 
 namespace Altis\Experiments\Features\Blocks;
 
+use Altis\Analytics\Audiences;
+use Altis\Analytics\Utils;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
 /**
  * Include and set up Experience Blocks.
  */
@@ -20,6 +26,9 @@ function setup() {
 
 	// Register experience block category.
 	add_filter( 'block_categories', __NAMESPACE__ . '\\add_block_category', 9 );
+
+	// Register API endpoints for getting XB analytics data.
+	add_action( 'rest_api_init', __NAMESPACE__ . '\\rest_api_init' );
 }
 
 /**
@@ -68,4 +77,249 @@ function get_block_settings( string $name ) : ?array {
 	}
 
 	return $settings;
+}
+
+/**
+ * Register REST API endpoints for Experience Blocks.
+ *
+ * @return void
+ */
+function rest_api_init() : void {
+
+	// Experience blocks views endpoint.
+	register_rest_route( 'analytics/v1', 'xbs/(?P<id>[a-z0-9-]+)/views', [
+		[
+			'methods' => WP_REST_Server::READABLE,
+			'callback' => __NAMESPACE__ . '\\handle_views_request',
+			'permission_callback' => __NAMESPACE__ . '\\check_views_permission',
+			'args' => [
+				'id' => [
+					'description' => __( 'The experience block client ID', 'altis-experiments' ),
+					'required' => true,
+					'type' => 'string',
+					'validate_callback' => __NAMESPACE__ . '\\validate_id',
+					'sanitize_callback' => __NAMESPACE__ . '\\sanitize_id',
+				],
+				'post_id' => [
+					'description' => __( 'An optional post ID to filter by.', 'altis-experiments' ),
+					'type' => 'number',
+				],
+			],
+		],
+		'schema' => [
+			'type' => 'object',
+			'properties' => [
+				'total' => [ 'type' => 'number' ],
+				'audiences' => [
+					'type' => 'array',
+					'items' => [
+						'type' => 'object',
+						'properties' => [
+							'id' => [ 'type' => 'number' ],
+							'count' => [ 'type' => 'number' ],
+						],
+					],
+				],
+				'posts' => [
+					'type' => 'array',
+					'items' => [
+						'type' => 'object',
+						'properties' => [
+							'id' => [ 'type' => 'number' ],
+							'count' => [ 'type' => 'number' ],
+							'audiences' => [
+								'type' => 'array',
+								'items' => [
+									'type' => 'object',
+									'properties' => [
+										'id' => [ 'type' => 'number' ],
+										'count' => [ 'type' => 'number' ],
+									],
+								],
+							],
+						],
+					],
+				],
+				'postId' => [ 'type' => 'number' ],
+			],
+		],
+	] );
+}
+
+/**
+ * Validate Experience Block ID.
+ *
+ * @param string $param The Experience Block ID.
+ * @return bool
+ */
+function validate_id( $param ) : bool {
+	return (bool) preg_match( '/[a-z0-9-]+/', $param );
+}
+
+/**
+ * Sanitize Experience Block ID.
+ *
+ * @param string $param The Experience Block ID.
+ * @return string
+ */
+function sanitize_id( $param ) : string {
+	return preg_replace( '/[^a-z0-9-]+/', '', $param );
+}
+
+/**
+ * Check current user can view XB analytics data.
+ *
+ * @return boolean
+ */
+function check_views_permission() : bool {
+	return true;
+	$type = get_post_type_object( Audiences\POST_TYPE );
+	return current_user_can( $type->cap->edit_posts );
+}
+
+/**
+ * Retrieve the Experience Block views data.
+ *
+ * @param WP_REST_Request $request The REST request object.
+ * @return WP_REST_Response
+ */
+function handle_views_request( WP_REST_Request $request ) : WP_REST_Response {
+	$block_id = $request->get_param( 'id' );
+	$post_id = $request->get_param( 'post_id' ) ?? null;
+	$views = get_views( $block_id, $post_id );
+	return rest_ensure_response( $views );
+}
+
+/**
+ * Get the Experience Block views data.
+ *
+ * @param string $block_id The Experience block client ID to get data for.
+ * @param int|null $post_id An optional post ID to limit results by.
+ * @return array|WP_Error
+ */
+function get_views( string $block_id, ?int $post_id = null ) {
+	$query = [
+		'query' => [
+			'bool' => [
+				'filter' => [
+					// Set current site.
+					[
+						'term' => [
+							'attributes.blogId.keyword' => get_current_blog_id(),
+						],
+					],
+
+					// Set block ID.
+					[
+						'term' => [
+							'attributes.clientId.keyword' => $block_id,
+						],
+					],
+
+					// Last month.
+					[
+						'range' => [
+							'event_timestamp' => [
+								'gte' => Utils\milliseconds() - ( MONTH_IN_SECONDS * 1000 ),
+							],
+						],
+					],
+
+					// Limit event type to experienceView.
+					[
+						'term' => [
+							'event_type.keyword' => 'experienceView',
+						],
+					],
+				],
+			],
+		],
+		'aggs' => [
+			// Get the split by audience.
+			'audiences' => [
+				'terms' => [
+					'field' => 'attributes.audience.keyword',
+				],
+			],
+
+			// Get the split by post ID and audience.
+			'posts' => [
+				'terms' => [
+					'field' => 'attributes.postId.keyword',
+				],
+				'aggs' => [
+					'audiences' => [
+						'terms' => [
+							'field' => 'attributes.audience.keyword',
+						],
+					],
+				],
+			],
+		],
+		'size' => 0,
+		'sort' => [
+			'event_timestamp' => 'desc',
+		],
+	];
+
+	// Add post ID query filter.
+	if ( $post_id ) {
+		// Remove the posts aggregation.
+		unset( $query['aggs']['posts'] );
+
+		$query['query']['bool']['filter'][] = [
+			'term' => [
+				'attributes.postId.keyword' => (string) $post_id,
+			],
+		];
+	}
+
+	$key = sprintf( 'views:%s', "{$block_id}:{$post_id}" );
+	$cache = wp_cache_get( $key, 'altis-xbs' );
+	if ( $cache ) {
+		return $cache;
+	}
+
+	$result = Utils\query( $query );
+
+	if ( ! $result ) {
+		return [
+			'total' => 0,
+		];
+	}
+
+	$audiences = array_map( function ( array $bucket ) {
+		return [
+			'id' => absint( $bucket['key'] ),
+			'count' => $bucket['doc_count'],
+		];
+	}, $result['aggregations']['audiences']['buckets'] );
+
+	$views = [
+		'total' => $result['hits']['total'],
+		'audiences' => $audiences,
+	];
+
+	// Add the posts aggregations.
+	if ( isset( $result['aggregations']['posts']['buckets'] ) ) {
+		$views['posts'] = array_map( function ( array $bucket ) {
+			$audiences = array_map( function ( array $bucket ) {
+				return [
+					'id' => absint( $bucket['key'] ),
+					'count' => $bucket['doc_count'],
+				];
+			}, $bucket['audiences']['buckets'] );
+			return [
+				'id' => absint( $bucket['key'] ),
+				'count' => $bucket['doc_count'],
+				'audiences' => $audiences,
+			];
+		}, $result['aggregations']['posts']['buckets'] );
+	} else {
+		$views['post_id'] = $post_id;
+	}
+
+	// wp_cache_set( $key, $views, 'altis-xbs', MINUTE_IN_SECONDS );
+
+	return $views;
 }

--- a/inc/features/blocks/personalization/components/block-analytics.js
+++ b/inc/features/blocks/personalization/components/block-analytics.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Views from './views';
 
 const { useSelect } = wp.data;
-const { __ } = wp.i18n;
+const { __, sprintf } = wp.i18n;
 
 const BlockAnalytics = ( { clientId } ) => {
 	const postId = useSelect( select => {
@@ -22,13 +22,17 @@ const BlockAnalytics = ( { clientId } ) => {
 		return select( 'analytics/xbs' ).getIsLoading();
 	}, [ views ] );
 
-	const total = views?.total;
+	const total = ( views && views.total ) || 0;
 
 	return (
 		<div className="altis-experience-block-analytics">
 			<h4>{ __( 'Analytics', 'altis-experiments' ) }</h4>
 			<p>{ __( 'Statisitics shown are for the configured data retention period.', 'altis-experiments' ) }</p>
-			<Views total={ total } isLoading={ isLoading } />
+			<Views
+				isLoading={ isLoading }
+				label={ sprintf( __( '%d total views', 'altis-experiments' ), total ) }
+				total={ total }
+			/>
 		</div>
 	);
 };

--- a/inc/features/blocks/personalization/components/block-analytics.js
+++ b/inc/features/blocks/personalization/components/block-analytics.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Views from './views';
 
 const { useSelect } = wp.data;
+const { __ } = wp.i18n;
 
 const BlockAnalytics = ( { clientId } ) => {
 	const postId = useSelect( select => {
@@ -24,7 +25,10 @@ const BlockAnalytics = ( { clientId } ) => {
 	const total = views?.total;
 
 	return (
-		<Views total={ total } isLoading={ isLoading } />
+		<div className="altis-experience-block-analytics">
+			<h4>{ __( 'Analytics' ) }</h4>
+			<Views total={ total } isLoading={ isLoading } />
+		</div>
 	);
 };
 

--- a/inc/features/blocks/personalization/components/block-analytics.js
+++ b/inc/features/blocks/personalization/components/block-analytics.js
@@ -27,7 +27,7 @@ const BlockAnalytics = ( { clientId } ) => {
 	return (
 		<div className="altis-experience-block-analytics">
 			<h4>{ __( 'Analytics', 'altis-experiments' ) }</h4>
-			<p>{ __( 'Statisitics shown are for the configured data retention period.', 'altis-experiments' ) }</p>
+			<p>{ __( 'Statistics shown are for the configured data retention period.', 'altis-experiments' ) }</p>
 			<Views
 				isLoading={ isLoading }
 				label={ sprintf( __( '%d total views', 'altis-experiments' ), total ) }

--- a/inc/features/blocks/personalization/components/block-analytics.js
+++ b/inc/features/blocks/personalization/components/block-analytics.js
@@ -26,7 +26,8 @@ const BlockAnalytics = ( { clientId } ) => {
 
 	return (
 		<div className="altis-experience-block-analytics">
-			<h4>{ __( 'Analytics' ) }</h4>
+			<h4>{ __( 'Analytics', 'altis-experiments' ) }</h4>
+			<p>{ __( 'Statisitics shown are for the configured data retention period.', 'altis-experiments' ) }</p>
 			<Views total={ total } isLoading={ isLoading } />
 		</div>
 	);

--- a/inc/features/blocks/personalization/components/block-analytics.js
+++ b/inc/features/blocks/personalization/components/block-analytics.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Views from './views';
+
+const { useSelect } = wp.data;
+
+const BlockAnalytics = ( { clientId } ) => {
+	const postId = useSelect( select => {
+		return select( 'core/editor' ).getCurrentPostId();
+	} );
+
+	// No post ID so post isn't published, don't show anything.
+	if ( ! postId ) {
+		return null;
+	}
+
+	// Fetch the stats.
+	const views = useSelect( select => {
+		return select( 'analytics/xbs' ).getViews( clientId, postId );
+	}, [ clientId, postId ] );
+	const isLoading = useSelect( select => {
+		return select( 'analytics/xbs' ).getIsLoading();
+	}, [ views ] );
+
+	const total = views?.total;
+
+	return (
+		<Views total={ total } isLoading={ isLoading } />
+	);
+};
+
+export default BlockAnalytics;

--- a/inc/features/blocks/personalization/components/variant-analytics.js
+++ b/inc/features/blocks/personalization/components/variant-analytics.js
@@ -36,10 +36,9 @@ const VariantAnalytics = ( { variant } ) => {
 	}, [ views ] );
 
 	const audienceId = audience || 0;
-
-	const audienceViews = views?.audiences?.
-		find( audienceData => audienceData.id === audienceId )?.
-		count || 0;
+	const audiencesData = ( views && views.audiences ) || [];
+	const audienceData = audiencesData.find( data => data.id === audienceId ) || {};
+	const audienceViews = audienceData.count || 0;
 
 	return (
 		<Views total={ audienceViews } isLoading={ isLoading } />

--- a/inc/features/blocks/personalization/components/variant-analytics.js
+++ b/inc/features/blocks/personalization/components/variant-analytics.js
@@ -35,7 +35,11 @@ const VariantAnalytics = ( { variant } ) => {
 		return select( 'analytics/xbs' ).getIsLoading();
 	}, [ views ] );
 
-	const audienceViews = views?.audiences.find( audienceData => audienceData.id === audience )?.count || 0;
+	const audienceId = audience || 0;
+
+	const audienceViews = views?.audiences?.
+		find( audienceData => audienceData.id === audienceId )?.
+		count || 0;
 
 	return (
 		<Views total={ audienceViews } isLoading={ isLoading } />

--- a/inc/features/blocks/personalization/components/variant-analytics.js
+++ b/inc/features/blocks/personalization/components/variant-analytics.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import Views from './views';
+
+const { useSelect } = wp.data;
+
+const VariantAnalytics = ( { variant } ) => {
+	const { audience, fallback } = variant.attributes;
+
+	// Show nothing if no audience selected and not the fallback.
+	if ( ! fallback && ! audience ) {
+		return null;
+	}
+
+	const postId = useSelect( select => {
+		return select( 'core/editor' ).getCurrentPostId();
+	} );
+
+	// No post ID so post isn't published, don't show anything.
+	if ( ! postId ) {
+		return null;
+	}
+
+	// Get the XB variant parent client ID.
+	const clientId = useSelect( select => {
+		const { getBlockAttributes, getBlockRootClientId } = select( 'core/block-editor' );
+		const parentClientId = getBlockRootClientId( variant.clientId );
+		return getBlockAttributes( parentClientId ).clientId;
+	}, [ variant.clientId ] );
+
+	// Fetch the stats.
+	const views = useSelect( select => {
+		return select( 'analytics/xbs' ).getViews( clientId, postId );
+	}, [ clientId, postId ] );
+	const isLoading = useSelect( select => {
+		return select( 'analytics/xbs' ).getIsLoading();
+	}, [ views ] );
+
+	const audienceViews = views?.audiences.find( audienceData => audienceData.id === audience )?.count || 0;
+
+	return (
+		<Views total={ audienceViews } isLoading={ isLoading } />
+	);
+};
+
+export default VariantAnalytics;

--- a/inc/features/blocks/personalization/components/variant-panel.js
+++ b/inc/features/blocks/personalization/components/variant-panel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import VariantAnalytics from './variant-analytics';
 import VariantTitle from './variant-title';
 
 const { AudiencePicker } = Altis.Analytics.components;
@@ -16,6 +17,7 @@ const VariantPanel = ( { variant } ) => {
 				<p className="description">
 					{ __( 'This variant will be shown as a fallback if no audiences are matched. You can leave the content empty if you do not wish to show anything.', 'altis-experiments' ) }
 				</p>
+				<VariantAnalytics variant={ variant } />
 			</PanelBody>
 		);
 	}
@@ -33,6 +35,7 @@ const VariantPanel = ( { variant } ) => {
 					{ __( 'You must select an audience for this variant.', 'altis-experiments' ) }
 				</p>
 			) }
+			<VariantAnalytics variant={ variant } />
 		</PanelBody>
 	);
 };

--- a/inc/features/blocks/personalization/components/variant-panel.js
+++ b/inc/features/blocks/personalization/components/variant-panel.js
@@ -15,7 +15,7 @@ const VariantPanel = ( { variant, placeholder = null } ) => {
 		return (
 			<PanelBody title={ __( 'Fallback', 'altis-experiments' ) }>
 				<p className="description">
-					{ __( 'This variant will be shown as a fallback if no audiences are matched. You can leave the content empty if you do not wish to show anything.', 'altis-experiments' ) }
+					{ __( 'This variant will be shown as a fallback if no audiences are matched.', 'altis-experiments' ) }
 				</p>
 				<VariantAnalytics variant={ variant } />
 			</PanelBody>
@@ -25,7 +25,6 @@ const VariantPanel = ( { variant, placeholder = null } ) => {
 	return (
 		<PanelBody title={ <VariantTitle variant={ variant } placeholder={ placeholder } /> }>
 			<AudiencePicker
-				label={ __( 'Audience', 'altis-experiments' ) }
 				audience={ variant.attributes.audience }
 				onSelect={ audience => updateBlockAttributes( variant.clientId, { audience } ) }
 				onClearSelection={ () => updateBlockAttributes( variant.clientId, { audience: null } ) }

--- a/inc/features/blocks/personalization/components/views.js
+++ b/inc/features/blocks/personalization/components/views.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const { Icon } = wp.components;
+const { __, _n, sprintf } = wp.i18n;
+
+const Views = ( { total, isLoading } ) => {
+	if ( ! total && isLoading ) {
+		return (
+			<p className="altis-analytics-views">
+				<Icon icon="visibility" />
+				{ ' ' }
+				{ __( 'Loading...', 'altis-experiments' ) }
+			</p>
+		);
+	}
+
+	if ( ! total ) {
+		return (
+			<p className="altis-analytics-views">
+				<Icon icon="visibility" />
+				{ ' ' }
+				{ __( 'No views yet', 'altis-experiments' ) }
+			</p>
+		);
+	}
+
+	return (
+		<p className="altis-analytics-views">
+			<Icon icon="visibility" />
+			{ sprintf( _n( '%d view', '%d views', total, 'altis-experiments' ), total ) }
+		</p>
+	);
+}
+
+export const Views;

--- a/inc/features/blocks/personalization/components/views.js
+++ b/inc/features/blocks/personalization/components/views.js
@@ -3,7 +3,7 @@ import React from 'react';
 const { Icon } = wp.components;
 const { __, _n, sprintf } = wp.i18n;
 
-const Views = ( { total, isLoading } ) => {
+const Views = ( { isLoading, label = null, total } ) => {
 	if ( ! total && isLoading ) {
 		return (
 			<p className="altis-analytics-views">
@@ -27,7 +27,7 @@ const Views = ( { total, isLoading } ) => {
 	return (
 		<p className="altis-analytics-views">
 			<Icon icon="visibility" />
-			{ sprintf( _n( '%d view', '%d views', total, 'altis-experiments' ), total ) }
+			{ label || sprintf( _n( '%d view', '%d views', total, 'altis-experiments' ), total ) }
 		</p>
 	);
 };

--- a/inc/features/blocks/personalization/components/views.js
+++ b/inc/features/blocks/personalization/components/views.js
@@ -30,6 +30,6 @@ const Views = ( { total, isLoading } ) => {
 			{ sprintf( _n( '%d view', '%d views', total, 'altis-experiments' ), total ) }
 		</p>
 	);
-}
+};
 
 export default Views;

--- a/inc/features/blocks/personalization/components/views.js
+++ b/inc/features/blocks/personalization/components/views.js
@@ -32,4 +32,4 @@ const Views = ( { total, isLoading } ) => {
 	);
 }
 
-export const Views;
+export default Views;

--- a/inc/features/blocks/personalization/data/analytics.js
+++ b/inc/features/blocks/personalization/data/analytics.js
@@ -24,7 +24,6 @@ const reducer = function reducer( state, action ) {
 			};
 		}
 
-
 		case 'SET_IS_LOADING': {
 			return {
 				...state,

--- a/inc/features/blocks/personalization/data/analytics.js
+++ b/inc/features/blocks/personalization/data/analytics.js
@@ -1,0 +1,108 @@
+/**
+ * Altis Analytics data store.
+ */
+
+const { apiFetch } = wp;
+const { registerStore } = wp.data;
+const { addQueryArgs } = wp.url;
+
+const initialState = {
+	views: {},
+	isLoading: false,
+};
+
+const reducer = function reducer( state, action ) {
+	switch ( action.type ) {
+		case 'ADD_VIEWS': {
+			const key = `${ action.clientId }${ action.postId ? `-${ action.postId }` : '' }`;
+			return {
+				...state,
+				views: {
+					...state.views,
+					[ key ]: action.views,
+				},
+			};
+		}
+
+
+		case 'SET_IS_LOADING': {
+			return {
+				...state,
+				isLoading: action.isLoading,
+			};
+		}
+
+		default: {
+			return state;
+		}
+	}
+};
+
+const controls = {
+	FETCH_FROM_API( action ) {
+		return apiFetch( action.options );
+	},
+	RESPONSE_TO_JSON( action ) {
+		return action.response.json();
+	},
+};
+
+const actions = {
+	addViews( clientId, postId, views ) {
+		return {
+			type: 'ADD_VIEWS',
+			clientId,
+			postId,
+			views,
+		};
+	},
+	setIsLoading( isLoading ) {
+		return {
+			type: 'SET_IS_LOADING',
+			isLoading,
+		};
+	},
+	fetch( options ) {
+		return {
+			type: 'FETCH_FROM_API',
+			options,
+		};
+	},
+	json( response ) {
+		return {
+			type: 'RESPONSE_TO_JSON',
+			response,
+		};
+	},
+};
+
+const selectors = {
+	getViews( state, clientId, postId = null ) {
+		return state.views[ `${ clientId }${ postId ? `-${ postId }` : '' }` ] || false;
+	},
+	getIsLoading( state ) {
+		return state.isLoading;
+	},
+};
+
+const resolvers = {
+	*getViews( clientId, postId = null ) {
+		yield actions.setIsLoading( true );
+		const response = yield actions.fetch( {
+			path: addQueryArgs( `analytics/v1/xbs/${ clientId }/views`, {
+				post_id: postId,
+			} ),
+		} );
+		yield actions.addViews( clientId, postId, response );
+		return actions.setIsLoading( false );
+	},
+};
+
+export const store = registerStore( 'analytics/xbs', {
+	actions,
+	controls,
+	initialState,
+	reducer,
+	resolvers,
+	selectors,
+} );

--- a/inc/features/blocks/personalization/data/analytics.js
+++ b/inc/features/blocks/personalization/data/analytics.js
@@ -24,6 +24,13 @@ const reducer = function reducer( state, action ) {
 			};
 		}
 
+		case 'REMOVE_VIEWS': {
+			const key = `${ action.clientId }${ action.postId ? `-${ action.postId }` : '' }`;
+			const newState = { ...state };
+			delete newState.views[ key ];
+			return newState;
+		}
+
 		case 'SET_IS_LOADING': {
 			return {
 				...state,
@@ -53,6 +60,13 @@ const actions = {
 			clientId,
 			postId,
 			views,
+		};
+	},
+	removeViews( clientId, postId ) {
+		return {
+			type: 'REMOVE_VIEWS',
+			clientId,
+			postId,
 		};
 	},
 	setIsLoading( isLoading ) {

--- a/inc/features/blocks/personalization/data/analytics.js
+++ b/inc/features/blocks/personalization/data/analytics.js
@@ -26,8 +26,7 @@ const reducer = function reducer( state, action ) {
 
 		case 'REMOVE_VIEWS': {
 			const key = `${ action.clientId }${ action.postId ? `-${ action.postId }` : '' }`;
-			const newState = { ...state };
-			delete newState.views[ key ];
+			const { [ key ]: deletedItem, ...newState } = state;
 			return newState;
 		}
 

--- a/inc/features/blocks/personalization/edit.css
+++ b/inc/features/blocks/personalization/edit.css
@@ -99,14 +99,19 @@
 	max-width: none;
 }
 
-.altis-variant-analytics {
+.altis-experience-block-analytics h4 {
+	margin-bottom: 4px;
+}
+
+.components-panel__body .altis-analytics-views {
+	margin-top: 4px;
 	font-size: 11px;
 }
 
-.altis-variant-analytics .dashicon {
+.altis-analytics-views .dashicon {
 	width: 1rem;
 	height: 1rem;
 	vertical-align: text-top;
 	margin-right: 4px;
-	margin-top: 1px;
+	margin-top: -1px;
 }

--- a/inc/features/blocks/personalization/edit.css
+++ b/inc/features/blocks/personalization/edit.css
@@ -98,3 +98,15 @@
 .wp-block[data-type="altis/personalization-variant"] .wp-block {
 	max-width: none;
 }
+
+.altis-variant-analytics {
+	font-size: 11px;
+}
+
+.altis-variant-analytics .dashicon {
+	width: 1rem;
+	height: 1rem;
+	vertical-align: text-top;
+	margin-right: 4px;
+	margin-top: 1px;
+}

--- a/inc/features/blocks/personalization/edit.js
+++ b/inc/features/blocks/personalization/edit.js
@@ -1,5 +1,6 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
+import BlockAnalytics from './components/block-analytics';
 import VariantTitle from './components/variant-title';
 import VariantPanel from './components/variant-panel';
 import VariantToolbar from './components/variant-toolbar';
@@ -108,6 +109,7 @@ const Edit = ( {
 					>
 						{ __( 'Add a variant', 'altis-experiments' ) }
 					</Button>
+					<BlockAnalytics clientId={ attributes.clientId } />
 				</div>
 				{ variants.map( ( variant, index ) => (
 					<VariantPanel

--- a/inc/features/blocks/personalization/index.js
+++ b/inc/features/blocks/personalization/index.js
@@ -1,6 +1,9 @@
 import edit from './edit';
 import save from './save';
 
+// Load analytics data store.
+import './data/analytics';
+
 import blockData from './block.json';
 
 const { registerBlockType } = wp.blocks;
@@ -14,6 +17,7 @@ const settings = {
 		__( 'personalize', 'altis-experiments' ),
 		__( 'conditional', 'altis-experiments' ),
 		__( 'audience', 'altis-experiments' ),
+		__( 'analytics', 'altis-experiments' ),
 	],
 	edit,
 	save,


### PR DESCRIPTION
This shows the basic views data inline along with the XB variants and the total views for the XB itself.

Introduces a new API endpoint for collecting variant stats.

Fixes https://github.com/humanmade/altis-analytics/issues/77