### PR TITLE
Add goal tracking for experience blocks

### DIFF
--- a/inc/features/blocks/namespace.php
+++ b/inc/features/blocks/namespace.php
@@ -9,6 +9,7 @@ namespace Altis\Experiments\Features\Blocks;
 
 use Altis\Analytics\Audiences;
 use Altis\Analytics\Utils;
+use Altis\Experiments;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -29,55 +30,6 @@ function setup() {
 
 	// Register API endpoints for getting XB analytics data.
 	add_action( 'rest_api_init', __NAMESPACE__ . '\\rest_api_init' );
-
-	// Register default conversion goals.
-	register_goal(
-		'click_any_link',
-		__( 'Click on any link', 'altis-experiments' ),
-		'click',
-		'a'
-	);
-	register_goal(
-		'submit_form',
-		__( 'Submit a form', 'altis-experiments' ),
-		'submit',
-		'form'
-	);
-}
-
-/**
- * Registers a new conversion goal for front end tracking.
- *
- * @param string $name A reference name for the goal.
- * @param string $label A human readable label for the goal.
- * @param string $event The JS event to trigger on.
- * @param string|null $selector An optional CSS selector to scope the event to.
- * @return void
- */
-function register_goal( string $name, string $label, string $event, ?string $selector = null, ?string $closest = null ) : void {
-	global $altis_experience_block_goals;
-
-	if ( ! is_array( $altis_experience_block_goals ) ) {
-		$altis_experience_block_goals = [];
-	}
-
-	$altis_experience_block_goals[ $name ] = [
-		'name' => $name,
-		'event' => sanitize_key( $event ),
-		'label' => $label,
-		'selector' => $selector,
-		'closest' => $closest,
-	];
-}
-
-/**
- * Returns registered goals.
- *
- * @return array
- */
-function get_goals() : array {
-	global $altis_experience_block_goals;
-	return $altis_experience_block_goals ?? [];
 }
 
 /**

--- a/inc/features/blocks/namespace.php
+++ b/inc/features/blocks/namespace.php
@@ -9,7 +9,6 @@ namespace Altis\Experiments\Features\Blocks;
 
 use Altis\Analytics\Audiences;
 use Altis\Analytics\Utils;
-use Altis\Experiments;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -241,7 +240,7 @@ function map_aggregations( array $event_buckets ) : array {
 					'conversions' => 0,
 				];
 			}
-			$data['audiences'][ $audience_bucket['key'] ][ $key ] += $audience_bucket['doc_count']	;
+			$data['audiences'][ $audience_bucket['key'] ][ $key ] += $audience_bucket['doc_count'];
 		}
 	}
 

--- a/inc/features/blocks/namespace.php
+++ b/inc/features/blocks/namespace.php
@@ -345,7 +345,7 @@ function get_views( string $block_id, ?int $post_id = null ) {
 	$key = sprintf( 'views:%s:%s', $block_id, $post_id );
 	$cache = wp_cache_get( $key, 'altis-xbs' );
 	if ( $cache ) {
-		// return $cache;
+		return $cache;
 	}
 
 	$result = Utils\query( $query );

--- a/inc/features/blocks/namespace.php
+++ b/inc/features/blocks/namespace.php
@@ -225,7 +225,6 @@ function map_aggregations( array $event_buckets ) : array {
 	];
 
 	foreach ( $event_buckets as $event_bucket ) {
-
 		$key = $event_type_map[ $event_bucket['key'] ];
 
 		// Set the total.

--- a/inc/features/blocks/personalization-variant/block.json
+++ b/inc/features/blocks/personalization-variant/block.json
@@ -16,6 +16,10 @@
             },
             "fallback": {
                 "type": "boolean"
+            },
+            "goal": {
+                "type": "string",
+                "default": ""
             }
         }
     }

--- a/inc/features/blocks/personalization-variant/register.php
+++ b/inc/features/blocks/personalization-variant/register.php
@@ -69,19 +69,22 @@ function enqueue_assets() {
 function render_block( array $attributes, ?string $inner_content = '' ) : string {
 	$audience = $attributes['audience'] ?? 0;
 	$fallback = $attributes['fallback'] ?? false;
+	$goal = $attributes['goal'] ?? '';
 
 	// If this is the fallback variant output the template with different attributes
 	// for easier and more specific targeting by document.querySelector().
 	if ( $fallback ) {
 		return sprintf(
-			'<template data-fallback data-parent-id="__PARENT_CLIENT_ID__">%s</template>',
+			'<template data-fallback data-parent-id="__PARENT_CLIENT_ID__" data-goal="%s">%s</template>',
+			esc_attr( $goal ),
 			$inner_content
 		);
 	}
 
 	return sprintf(
-		'<template data-audience="%d" data-parent-id="__PARENT_CLIENT_ID__">%s</template>',
+		'<template data-audience="%d" data-parent-id="__PARENT_CLIENT_ID__" data-goal="%s">%s</template>',
 		esc_attr( $audience ),
+		esc_attr( $goal ),
 		$inner_content
 	);
 }

--- a/inc/features/blocks/personalization/components/block-analytics.js
+++ b/inc/features/blocks/personalization/components/block-analytics.js
@@ -15,14 +15,15 @@ const BlockAnalytics = ( { clientId } ) => {
 	}
 
 	// Fetch the stats.
-	const views = useSelect( select => {
+	const data = useSelect( select => {
 		return select( 'analytics/xbs' ).getViews( clientId, postId );
 	}, [ clientId, postId ] );
 	const isLoading = useSelect( select => {
 		return select( 'analytics/xbs' ).getIsLoading();
-	}, [ views ] );
+	}, [ data ] );
 
-	const total = ( views && views.total ) || 0;
+	const totalLoads = ( data && data.loads ) || 0;
+	const totalViews = ( data && data.views ) || 0;
 
 	return (
 		<div className="altis-experience-block-analytics">
@@ -30,8 +31,10 @@ const BlockAnalytics = ( { clientId } ) => {
 			<p>{ __( 'Statistics shown are for the configured data retention period.', 'altis-experiments' ) }</p>
 			<Views
 				isLoading={ isLoading }
-				label={ sprintf( __( '%d total views', 'altis-experiments' ), total ) }
-				total={ total }
+				label={ sprintf( __( '%d total page views', 'altis-experiments' ), totalLoads ) }
+				conversionsLabel={ sprintf( __( '%d block views', 'altis-experiments' ), totalViews ) }
+				total={ totalLoads }
+				conversions={ totalViews }
 			/>
 		</div>
 	);

--- a/inc/features/blocks/personalization/components/block-analytics.js
+++ b/inc/features/blocks/personalization/components/block-analytics.js
@@ -30,11 +30,11 @@ const BlockAnalytics = ( { clientId } ) => {
 			<h4>{ __( 'Analytics', 'altis-experiments' ) }</h4>
 			<p>{ __( 'Statistics shown are for the configured data retention period.', 'altis-experiments' ) }</p>
 			<Views
+				conversions={ totalViews }
+				conversionsLabel={ sprintf( __( '%d block views', 'altis-experiments' ), totalViews ) }
 				isLoading={ isLoading }
 				label={ sprintf( __( '%d total page views', 'altis-experiments' ), totalLoads ) }
-				conversionsLabel={ sprintf( __( '%d block views', 'altis-experiments' ), totalViews ) }
 				total={ totalLoads }
-				conversions={ totalViews }
 			/>
 		</div>
 	);

--- a/inc/features/blocks/personalization/components/goal-picker.js
+++ b/inc/features/blocks/personalization/components/goal-picker.js
@@ -20,7 +20,7 @@ const GoalPicker = ( { goal, onChange } ) => {
 		...goals.map( ( [ name, data ] ) => ( {
 			label: data.label || name,
 			value: name,
-		} ),
+		} ) ),
 	];
 
 	return (

--- a/inc/features/blocks/personalization/components/goal-picker.js
+++ b/inc/features/blocks/personalization/components/goal-picker.js
@@ -6,7 +6,6 @@ const { __ } = wp.i18n;
 const registeredGoals = window.Altis.Analytics.Experiments.Goals || {};
 
 const GoalPicker = ( { goal, onChange } ) => {
-
 	const goals = Object.entries( registeredGoals );
 
 	if ( goals.length < 1 ) {
@@ -18,15 +17,11 @@ const GoalPicker = ( { goal, onChange } ) => {
 			label: __( 'Impressions', 'altis-experiments' ),
 			value: '',
 		},
-	];
-
-	// Add registered goals to dropdown.
-	goals.forEach( ( [ name, data ] ) => {
-		options.push( {
+		...goals.map( ( [ name, data ] ) => ( {
 			label: data.label || name,
 			value: name,
-		} );
-	} );
+		} ),
+	];
 
 	return (
 		<SelectControl

--- a/inc/features/blocks/personalization/components/goal-picker.js
+++ b/inc/features/blocks/personalization/components/goal-picker.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const { SelectControl } = wp.components;
+const { __ } = wp.i18n;
+
+const registeredGoals = window.Altis.Analytics.Experiments.Goals || {};
+
+const GoalPicker = ( { goal, onChange } ) => {
+
+    const goals = Object.entries( registeredGoals );
+
+    if ( goals.length < 1 ) {
+        return null;
+    }
+
+    const options = [
+        { label: __( 'Impressions', 'altis-experiments' ), value: '' },
+    ];
+
+    // Add registered goals to dropdown.
+    goals.forEach( ( [ name, data ] ) => {
+        options.push( { label: data.label || name, value: name } );
+    } );
+
+    return (
+        <SelectControl
+            label={ __( 'Choose a conversion goal', 'altis-experiments' ) }
+            value={ goal }
+            options={ options }
+            onChange={ onChange }
+        />
+    );
+};
+
+export default GoalPicker;

--- a/inc/features/blocks/personalization/components/goal-picker.js
+++ b/inc/features/blocks/personalization/components/goal-picker.js
@@ -26,9 +26,9 @@ const GoalPicker = ( { goal, onChange } ) => {
 	return (
 		<SelectControl
 			label={ __( 'Choose a conversion goal', 'altis-experiments' ) }
-			value={ goal }
-			options={ options }
 			onChange={ onChange }
+			options={ options }
+			value={ goal }
 		/>
 	);
 };

--- a/inc/features/blocks/personalization/components/goal-picker.js
+++ b/inc/features/blocks/personalization/components/goal-picker.js
@@ -22,7 +22,10 @@ const GoalPicker = ( { goal, onChange } ) => {
 
 	// Add registered goals to dropdown.
 	goals.forEach( ( [ name, data ] ) => {
-		options.push( { label: data.label || name, value: name } );
+		options.push( {
+			label: data.label || name,
+			value: name,
+		} );
 	} );
 
 	return (

--- a/inc/features/blocks/personalization/components/goal-picker.js
+++ b/inc/features/blocks/personalization/components/goal-picker.js
@@ -7,29 +7,32 @@ const registeredGoals = window.Altis.Analytics.Experiments.Goals || {};
 
 const GoalPicker = ( { goal, onChange } ) => {
 
-    const goals = Object.entries( registeredGoals );
+	const goals = Object.entries( registeredGoals );
 
-    if ( goals.length < 1 ) {
-        return null;
-    }
+	if ( goals.length < 1 ) {
+		return null;
+	}
 
-    const options = [
-        { label: __( 'Impressions', 'altis-experiments' ), value: '' },
-    ];
+	const options = [
+		{
+			label: __( 'Impressions', 'altis-experiments' ),
+			value: '',
+		},
+	];
 
-    // Add registered goals to dropdown.
-    goals.forEach( ( [ name, data ] ) => {
-        options.push( { label: data.label || name, value: name } );
-    } );
+	// Add registered goals to dropdown.
+	goals.forEach( ( [ name, data ] ) => {
+		options.push( { label: data.label || name, value: name } );
+	} );
 
-    return (
-        <SelectControl
-            label={ __( 'Choose a conversion goal', 'altis-experiments' ) }
-            value={ goal }
-            options={ options }
-            onChange={ onChange }
-        />
-    );
+	return (
+		<SelectControl
+			label={ __( 'Choose a conversion goal', 'altis-experiments' ) }
+			value={ goal }
+			options={ options }
+			onChange={ onChange }
+		/>
+	);
 };
 
 export default GoalPicker;

--- a/inc/features/blocks/personalization/components/variant-analytics.js
+++ b/inc/features/blocks/personalization/components/variant-analytics.js
@@ -38,9 +38,6 @@ const VariantAnalytics = ( { variant } ) => {
 	const audienceId = audience || 0;
 
 	// Total loads, views & conversions.
-	let conversions = null;
-	let conversionsDenominator = null;
-
 	const audiences = ( data && data.audiences ) || [];
 	const audienceData = audiences.find( data => data.id === audienceId ) || {};
 	const total = audienceData.views;

--- a/inc/features/blocks/personalization/components/variant-analytics.js
+++ b/inc/features/blocks/personalization/components/variant-analytics.js
@@ -45,19 +45,15 @@ const VariantAnalytics = ( { variant } ) => {
 	const audienceData = audiences.find( data => data.id === audienceId ) || {};
 	const total = audienceData.views;
 
-	if ( variant.attributes.goal ) {
-		conversions = audienceData.conversions;
-	} else {
-		conversions = audienceData.views;
-		conversionsDenominator = audienceData.loads;
-	}
+	const conversions = variant.attributes.goal ? audienceData.conversions : audienceData.views;
+	const conversionsDenominator = variant.attributes.goal ? null : audienceData.loads;
 
 	return (
 		<Views
-			isLoading={ isLoading }
-			total={ total }
 			conversions={ conversions }
 			conversionsDenominator={ conversionsDenominator }
+			isLoading={ isLoading }
+			total={ total }
 		/>
 	);
 };

--- a/inc/features/blocks/personalization/components/variant-analytics.js
+++ b/inc/features/blocks/personalization/components/variant-analytics.js
@@ -28,20 +28,37 @@ const VariantAnalytics = ( { variant } ) => {
 	}, [ variant.clientId ] );
 
 	// Fetch the stats.
-	const views = useSelect( select => {
+	const data = useSelect( select => {
 		return select( 'analytics/xbs' ).getViews( clientId, postId );
 	}, [ clientId, postId ] );
 	const isLoading = useSelect( select => {
 		return select( 'analytics/xbs' ).getIsLoading();
-	}, [ views ] );
+	}, [ data ] );
 
 	const audienceId = audience || 0;
-	const audiencesData = ( views && views.audiences ) || [];
-	const audienceData = audiencesData.find( data => data.id === audienceId ) || {};
-	const audienceViews = audienceData.count || 0;
+
+	// Total loads, views & conversions.
+	let conversions = null;
+	let conversionsDenominator = null;
+
+	const audiences = ( data && data.audiences ) || [];
+	const audienceData = audiences.find( data => data.id === audienceId ) || {};
+	const total = audienceData.views;
+
+	if ( variant.attributes.goal ) {
+		conversions = audienceData.conversions;
+	} else {
+		conversions = audienceData.views;
+		conversionsDenominator = audienceData.loads;
+	}
 
 	return (
-		<Views total={ audienceViews } isLoading={ isLoading } />
+		<Views
+			isLoading={ isLoading }
+			total={ total }
+			conversions={ conversions }
+			conversionsDenominator={ conversionsDenominator }
+		/>
 	);
 };
 

--- a/inc/features/blocks/personalization/components/variant-panel.js
+++ b/inc/features/blocks/personalization/components/variant-panel.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import GoalPicker from './goal-picker';
 import VariantAnalytics from './variant-analytics';
 import VariantTitle from './variant-title';
 
@@ -17,6 +18,10 @@ const VariantPanel = ( { variant, placeholder = null } ) => {
 				<p className="description">
 					{ __( 'This variant will be shown as a fallback if no audiences are matched.', 'altis-experiments' ) }
 				</p>
+				<GoalPicker
+					goal={ variant.attributes.goal }
+					onChange={ goal => updateBlockAttributes( variant.clientId, { goal } ) }
+				/>
 				<VariantAnalytics variant={ variant } />
 			</PanelBody>
 		);
@@ -34,6 +39,10 @@ const VariantPanel = ( { variant, placeholder = null } ) => {
 					{ __( 'You must select an audience for this variant.', 'altis-experiments' ) }
 				</p>
 			) }
+			<GoalPicker
+				goal={ variant.attributes.goal }
+				onChange={ goal => updateBlockAttributes( variant.clientId, { goal } ) }
+			/>
 			<VariantAnalytics variant={ variant } />
 		</PanelBody>
 	);

--- a/inc/features/blocks/personalization/components/views.js
+++ b/inc/features/blocks/personalization/components/views.js
@@ -9,7 +9,7 @@ const Views = ( {
 	conversionsLabel = null,
 	isLoading,
 	label = null,
-	total
+	total,
 } ) => {
 	if ( ! total && isLoading ) {
 		return (

--- a/inc/features/blocks/personalization/components/views.js
+++ b/inc/features/blocks/personalization/components/views.js
@@ -31,7 +31,7 @@ const Views = ( {
 		);
 	}
 
-	const conversionPercent = ( ( conversions / ( conversionsDenominator || total ) ) * 100 ).toFixed( 1 );
+	const conversionPercent = ( conversions / ( conversionsDenominator || total ) ) * 100;
 
 	return (
 		<div className="altis-analytics-views">
@@ -43,7 +43,7 @@ const Views = ( {
 				<Icon icon="yes" />
 				{ conversionsLabel || sprintf( _n( '%d conversion', '%d conversions', conversions, 'altis-experiments' ), conversions ) }
 				{ ' ' }
-				({ conversionPercent }%)
+				({ conversionPercent.toFixed( 1 ) }%)
 			</div>
 		</div>
 	);

--- a/inc/features/blocks/personalization/components/views.js
+++ b/inc/features/blocks/personalization/components/views.js
@@ -31,6 +31,8 @@ const Views = ( {
 		);
 	}
 
+	const conversionPercent = ( ( conversions / ( conversionsDenominator || total ) ) * 100 ).toFixed( 1 );
+
 	return (
 		<div className="altis-analytics-views">
 			<div className="altis-analytics-views__total">
@@ -41,7 +43,7 @@ const Views = ( {
 				<Icon icon="yes" />
 				{ conversionsLabel || sprintf( _n( '%d conversion', '%d conversions', conversions, 'altis-experiments' ), conversions ) }
 				{ ' ' }
-				({ ( ( conversions / ( conversionsDenominator || total ) ) * 100 ).toFixed( 1 ) }%)
+				({ conversionPercent }%)
 			</div>
 		</div>
 	);

--- a/inc/features/blocks/personalization/components/views.js
+++ b/inc/features/blocks/personalization/components/views.js
@@ -3,7 +3,14 @@ import React from 'react';
 const { Icon } = wp.components;
 const { __, _n, sprintf } = wp.i18n;
 
-const Views = ( { isLoading, label = null, total } ) => {
+const Views = ( {
+	conversions,
+	conversionsDenominator = null,
+	conversionsLabel = null,
+	isLoading,
+	label = null,
+	total
+} ) => {
 	if ( ! total && isLoading ) {
 		return (
 			<p className="altis-analytics-views">
@@ -25,10 +32,18 @@ const Views = ( { isLoading, label = null, total } ) => {
 	}
 
 	return (
-		<p className="altis-analytics-views">
-			<Icon icon="visibility" />
-			{ label || sprintf( _n( '%d view', '%d views', total, 'altis-experiments' ), total ) }
-		</p>
+		<div className="altis-analytics-views">
+			<div className="altis-analytics-views__total">
+				<Icon icon="visibility" />
+				{ label || sprintf( _n( '%d view', '%d views', total, 'altis-experiments' ), total ) }
+			</div>
+			<div className="altis-analytics-views__conversions">
+				<Icon icon="yes" />
+				{ conversionsLabel || sprintf( _n( '%d conversion', '%d conversions', conversions, 'altis-experiments' ), conversions ) }
+				{ ' ' }
+				({ ( ( conversions / ( conversionsDenominator || total ) ) * 100 ).toFixed( 1 ) }%)
+			</div>
+		</div>
 	);
 };
 

--- a/inc/features/blocks/personalization/register.php
+++ b/inc/features/blocks/personalization/register.php
@@ -55,13 +55,15 @@ function enqueue_assets() {
 	);
 
 	wp_add_inline_script(
-		'altis-experiments-features-blocks-experience',
+		'altis-experiments-features-blocks-personalization',
 		sprintf(
 			'window.Altis = window.Altis || {};' .
 			'window.Altis.Analytics = window.Altis.Analytics || {};' .
 			'window.Altis.Analytics.Experiments = window.Altis.Analytics.Experiments || {};' .
-			'window.Altis.Analytics.Experiments.BuildURL = %s;',
-			wp_json_encode( plugins_url( 'build', Experiments\ROOT_FILE ) )
+			'window.Altis.Analytics.Experiments.BuildURL = %s;' .
+			'window.Altis.Analytics.Experiments.Goals = %s;',
+			wp_json_encode( plugins_url( 'build', Experiments\ROOT_FILE ) ),
+			wp_json_encode( (object) Blocks\get_goals() )
 		),
 		'before'
 	);

--- a/inc/features/blocks/personalization/register.php
+++ b/inc/features/blocks/personalization/register.php
@@ -63,7 +63,7 @@ function enqueue_assets() {
 			'window.Altis.Analytics.Experiments.BuildURL = %s;' .
 			'window.Altis.Analytics.Experiments.Goals = %s;',
 			wp_json_encode( plugins_url( 'build', Experiments\ROOT_FILE ) ),
-			wp_json_encode( (object) Blocks\get_goals() )
+			wp_json_encode( (object) Experiments\get_goals() )
 		),
 		'before'
 	);

--- a/inc/features/titles/namespace.php
+++ b/inc/features/titles/namespace.php
@@ -112,6 +112,7 @@ function init() {
 		[
 			'label' => __( 'Titles', 'altis-experiments' ),
 			'goal' => 'click',
+			'closest' => 'a',
 			// Exclude all events from the target post page.
 			'query_filter' => function ( $test_id, $post_id ) : array {
 				$url = get_the_permalink( $post_id );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -7,7 +7,6 @@
 
 namespace Altis\Experiments;
 
-use Altis\Experiments\Features\Blocks;
 use function Altis\Analytics\Utils\merge_aggregates;
 use function Altis\Analytics\Utils\milliseconds;
 use function Altis\Analytics\Utils\query;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -113,6 +113,7 @@ function enqueue_scripts() {
  * @param string $label A human readable label for the goal.
  * @param string $event The JS event to trigger on.
  * @param string|null $selector An optional CSS selector to scope the event to.
+ * @param string|null $closest An optional CSS selector for finding the closest matching parent to bind the event to.
  * @return void
  */
 function register_goal( string $name, string $label, string $event, ?string $selector = null, ?string $closest = null ) : void {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -58,6 +58,20 @@ function setup() {
 		require_once ROOT_DIR . '/inc/features/blocks/namespace.php';
 		Features\Blocks\setup();
 	}
+
+	// Register default conversion goals.
+	register_goal(
+		'click_any_link',
+		__( 'Click on any link', 'altis-experiments' ),
+		'click',
+		'a'
+	);
+	register_goal(
+		'submit_form',
+		__( 'Submit a form', 'altis-experiments' ),
+		'submit',
+		'form'
+	);
 }
 
 /**
@@ -84,13 +98,48 @@ function enqueue_scripts() {
 			'window.Altis.Analytics.Experiments.BuildURL = %s;' .
 			'window.Altis.Analytics.Experiments.Goals = %s;',
 			wp_json_encode( plugins_url( 'build', dirname( __FILE__ ) ) ),
-			wp_json_encode( (object) Blocks\get_goals() )
+			wp_json_encode( (object) get_goals() )
 		),
 		'before'
 	);
 
 	// Load async.
 	$wp_scripts->add_data( 'altis-experiments', 'async', true );
+}
+
+/**
+ * Registers a new conversion goal for front end tracking.
+ *
+ * @param string $name A reference name for the goal.
+ * @param string $label A human readable label for the goal.
+ * @param string $event The JS event to trigger on.
+ * @param string|null $selector An optional CSS selector to scope the event to.
+ * @return void
+ */
+function register_goal( string $name, string $label, string $event, ?string $selector = null, ?string $closest = null ) : void {
+	global $altis_analytics_goals;
+
+	if ( ! is_array( $altis_analytics_goals ) ) {
+		$altis_analytics_goals = [];
+	}
+
+	$altis_analytics_goals[ $name ] = [
+		'name' => $name,
+		'event' => sanitize_key( $event ),
+		'label' => $label,
+		'selector' => $selector,
+		'closest' => $closest,
+	];
+}
+
+/**
+ * Returns registered goals.
+ *
+ * @return array
+ */
+function get_goals() : array {
+	global $altis_analytics_goals;
+	return $altis_analytics_goals ?? [];
 }
 
 /**

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -220,7 +220,11 @@ const registerGoalHandler = ( name, callback, closest = [] ) => {
  * @param {*} on The JS dvent name to listen on.
  */
 const bindListener = ( node, record, on ) => node && node.addEventListener( on, event => {
-	typeof record === 'function' && record( event );
+	if ( typeof record !== 'function' ) {
+		console.error( 'Altis Analytics goal handler is not a function', node, event );
+		return;
+	}
+	record( event );
 } );
 
 /**

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -241,7 +241,7 @@ const getGoalHandler = ( name, options = {} ) => {
 		callback: bindListener,
 		...( window.Altis.Analytics.Experiments.Goals[ name ] || {} ),
 		...( goalHandlers[ name ] || {} ),
-		...options
+		...options,
 	};
 
 	// Return a callback that handles the goal configuration and binds event listeners.

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -231,16 +231,14 @@ const bindListener = ( node, record, on ) => node && node.addEventListener( on, 
  */
 const getGoalHandler = ( name, options = {} ) => {
 	// Compile the goal configuration.
-	const goal = Object.assign(
-		{
-			name,
-			event: name,
-			callback: bindListener,
-		},
-		window.Altis.Analytics.Experiments.Goals[ name ] || {},
-		goalHandlers[ name ] || {},
-		options
-	);
+	const goal = {
+		name,
+		event: name,
+		callback: bindListener,
+		...( window.Altis.Analytics.Experiments.Goals[ name ] || {} ),
+		...( goalHandlers[ name ] || {} ),
+		...options
+	};
 
 	// Return a callback that handles the goal configuration and binds event listeners.
 	return ( node, record ) => {

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -231,7 +231,8 @@ const bindListener = ( node, record, on ) => node && node.addEventListener( on, 
  */
 const getGoalHandler = ( name, options = {} ) => {
 	// Compile the goal configuration.
-	const goal = Object.assign( {
+	const goal = Object.assign(
+		{
 			name,
 			event: name,
 			callback: bindListener,


### PR DESCRIPTION
Fixes #76

- Adds PHP `register_goal()` API to expose goal options in admin UI
- Adds goal picker for XB variations
- Updated XB views data endpoint to show totals per event type - load, view and conversion
- Updated client side goal handler code to work with server side code