### PR TITLE
Prevent error if zero hits returned

### DIFF
--- a/inc/features/blocks/namespace.php
+++ b/inc/features/blocks/namespace.php
@@ -359,7 +359,7 @@ function get_views( string $block_id, ?int $post_id = null ) {
 	}
 
 	// Collect metrics.
-	$data = map_aggregations( $result['aggregations']['events']['buckets'] );
+	$data = map_aggregations( $result['aggregations']['events']['buckets'] ?? [] );
 
 	// Add the post ID or posts aggregation.
 	if ( $post_id ) {


### PR DESCRIPTION
The aggregations key is missing from elasticsearch results if there are no hits, the code did not account for this.