### PR TITLE
Fix impression conversion goal display

### DIFF
--- a/inc/features/blocks/personalization/components/variant-analytics.js
+++ b/inc/features/blocks/personalization/components/variant-analytics.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Views from './views';
 
 const { useSelect } = wp.data;
+const { _n, sprintf } = wp.i18n;
 
 const VariantAnalytics = ( { variant } ) => {
 	const { audience, fallback } = variant.attributes;
@@ -40,17 +41,26 @@ const VariantAnalytics = ( { variant } ) => {
 	// Total loads, views & conversions.
 	const audiences = ( data && data.audiences ) || [];
 	const audienceData = audiences.find( data => data.id === audienceId ) || {};
-	const total = audienceData.views;
 
-	const conversions = variant.attributes.goal ? audienceData.conversions : audienceData.views;
-	const conversionsDenominator = variant.attributes.goal ? null : audienceData.loads;
+	// Use conversions vs total views if a goal is set.
+	if ( variant.attributes.goal ) {
+		return (
+			<Views
+				conversions={ audienceData.conversions }
+				isLoading={ isLoading }
+				total={ audienceData.views }
+			/>
+		);
+	}
 
+	// Use page loads vs block views if no goal is set e.g. show the number of impressions.
 	return (
 		<Views
-			conversions={ conversions }
-			conversionsDenominator={ conversionsDenominator }
+			conversions={ audienceData.views }
+			conversionsLabel={ sprintf( _n( '%d view', '%d views', audienceData.views, 'altis-experiments' ), audienceData.views ) }
 			isLoading={ isLoading }
-			total={ total }
+			label={ sprintf( _n( '%d page load', '%d page loads', audienceData.loads, 'altis-experiments' ), audienceData.loads ) }
+			total={ audienceData.loads }
 		/>
 	);
 };

--- a/inc/features/blocks/personalization/components/views.js
+++ b/inc/features/blocks/personalization/components/views.js
@@ -5,7 +5,6 @@ const { __, _n, sprintf } = wp.i18n;
 
 const Views = ( {
 	conversions,
-	conversionsDenominator = null,
 	conversionsLabel = null,
 	isLoading,
 	label = null,
@@ -31,7 +30,7 @@ const Views = ( {
 		);
 	}
 
-	const conversionPercent = ( conversions / ( conversionsDenominator || total ) ) * 100;
+	const conversionPercent = ( conversions / total ) * 100;
 
 	return (
 		<div className="altis-analytics-views">

--- a/inc/features/blocks/personalization/data/edit.js
+++ b/inc/features/blocks/personalization/data/edit.js
@@ -29,6 +29,7 @@ const withData = Component => compose(
 				const newVariant = createBlock( 'altis/personalization-variant', {
 					audience: null,
 					fallback: false,
+					goal: '',
 					...attributes,
 				}, [] );
 


### PR DESCRIPTION
The logic used to show conversion rate for impressions was a bit convoluted, this simplifies it and makes it clearer. Theres a wider issue and discussion regarding how we invalidate data when a block is edited so that the data is meaningful but will address that in a separate issue and PR.

Addresses https://github.com/humanmade/altis-analytics/issues/111 in part