### PR TITLE
Allow contributors to see XB analytics

### DIFF
--- a/inc/features/blocks/namespace.php
+++ b/inc/features/blocks/namespace.php
@@ -186,8 +186,7 @@ function sanitize_id( $param ) : string {
  * @return boolean
  */
 function check_views_permission() : bool {
-	$type = get_post_type_object( Audiences\POST_TYPE );
-	return current_user_can( $type->cap->edit_posts );
+	return current_user_can( 'edit_posts' );
 }
 
 /**


### PR DESCRIPTION
Contributors could create XBs but not see the stats for the blocks. This changes the permission to use the primitive `edit_posts` permission to restrict the endpoint to all those who can create content of any kind.