### PR TITLE
Allow null return value from AB test output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# v2.4.3
+
+- Bug: Allow null return type from output_ab_test_html function.
+
 # v2.4.2
 
 - Update: Use audience read capability for viewing XB analytics

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -700,9 +700,9 @@ function save_ab_test_results_for_post( string $test_id, int $post_id, array $da
  * @param integer $post_id The post ID for the test.
  * @param string $default_output The fallback / control variant output.
  * @param array $args Optional array of args to pass through to the `variant_callback`.
- * @return string
+ * @return string|null
  */
-function output_ab_test_html_for_post( string $test_id, int $post_id, string $default_output, array $args = [] ) : string {
+function output_ab_test_html_for_post( string $test_id, int $post_id, string $default_output, array $args = [] ) : ?string {
 	$test = get_post_ab_test( $test_id );
 
 	// Check post type is supported.

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Altis Experiments
  * Description: A companion plugin to Altis Analytics that provides a web experimentation framework.
- * Version: 2.4.2
+ * Version: 2.4.3
  * Author: Human Made Limited
  * Author URL: https://humanmade.com/
  */


### PR DESCRIPTION
Hotfix for a fatal error that technically shouldn't be possible but here we are.